### PR TITLE
docs: add media playback architecture ADR and implementation plan

### DIFF
--- a/docs/adr/0001-media-playback-architecture.md
+++ b/docs/adr/0001-media-playback-architecture.md
@@ -1,0 +1,199 @@
+# ADR 0001: Media Playback Architecture
+
+- **Status**: Proposed
+- **Date**: 2026-05-14
+- **Branch**: `claude/bot-video-playback-1ZjMY`
+
+## Context
+
+ZoomGate currently exposes Zoom waiting-room access control by joining a
+meeting as a lightweight pure-Elixir bot that speaks Zoom's RWG WebSocket
+protocol directly (~10 MB image, no SDK, no browser).
+
+A new requirement: the system must be able to **play a pre-recorded video
+(with audio)** into a meeting so participants see and hear it as if a
+participant were sharing media. Concrete shape of the requirement:
+
+- Video + audio together (audio-only is not acceptable; video is 99% of use)
+- Long-form content (30 min+ per item)
+- Eventually: playlist of items, with subtitle support
+- Playback controls from the controlling app: pause, resume, skip, seek
+- Concurrent target: **5 sessions** on a single host (YAGNI ceiling)
+- Acceptable start latency: **5 s**
+- Internal-only deployment (no Zoom Marketplace listing required)
+
+### Why the current architecture cannot do this
+
+The RWG WebSocket is a signalling/control channel only. It carries roster
+events, hold-change, chat, mute, expel, etc. — but no media plane. The
+official Zoom clients carry media over a separate WebRTC (Web SDK) or
+internal proprietary transport (Native SDK). To send media as a bot, we
+need an actual SDK integration; reverse-engineering the WebRTC media
+plane is not realistic.
+
+## Decision
+
+Adopt a **two-bot split architecture**: every meeting that needs media
+playback has **two independent Zoom participants**, each handled by a
+different service:
+
+```
+┌─ Application (GsNet etc.) ───────────────────────────────────────┐
+│                                                                  │
+└────────────────┬─────────────────────────────────────────────────┘
+                 │ BEAM / WS / REST
+                 ↓
+┌─ zoom_gate (Elixir, ~10 MB) ─────────────────────── Control plane │
+│  • Session GenServer per meeting                                 │
+│  • RWG WebSocket — waiting-room admit/deny/chat/expel/mute       │
+│  • MediaBot orchestrator client (HTTP)                           │
+└────────────────┬───────────────────────┬─────────────────────────┘
+                 │ join as Bot#1         │ HTTP /sessions
+                 │ (signalling only)     ↓
+                 ↓                ┌─ zoom_mediabot (~ hundreds MB) ─┐
+          ┌──────────────┐        │ • Native SDK or headless Chrome │
+          │  Zoom cloud  │ ← Bot#2│ • FFmpeg media pipeline         │
+          │  (meeting)   │ join   │ • Per-session worker subprocess │
+          └──────────────┘        │ • HTTP API for control          │
+                                  └─────────────────────────────────┘
+```
+
+### Key properties
+
+1. **The two bots do not talk to each other directly.** Both join the
+   meeting as independent Zoom participants. Coordination is done by
+   the orchestrator (ZoomGate).
+2. **The control bot pre-registers the media bot.** When ZoomGate is
+   asked to play media, it (a) records an expected identifier in its
+   Session state, (b) tells `zoom_mediabot` to join, (c) when the bot
+   appears in the RWG waiting-room event with that identifier, ZoomGate
+   immediately admits it.
+3. **Identifier field**: `email` (e.g., `mediabot-<uuid>@internal.local`).
+   `display_name` is reserved for app-controlled labels visible to
+   participants (e.g. session title). Pre-registration uses email so
+   display_name can be anything.
+4. **HTTP interface between ZoomGate and mediabot.** Not Erlang Port
+   (would couple the heavy media stack to the BEAM image, defeating the
+   10 MB control-plane goal), not `durable_server` (that solves
+   GenServer-state persistence, not OS-process supervision).
+5. **Co-located on a single host at first.** Docker Compose with two
+   services on `localhost`. Same HTTP interface migrates unchanged to
+   K8s when scale demands it.
+6. **`zoom_mediabot` lives in this monorepo** under `mediabot/`.
+
+### Internal implementation of `zoom_mediabot`: A vs B
+
+Two candidate implementations were considered:
+
+- **Option A — Native C++ Zoom Meeting SDK for Linux** + `IZoomSDKVideoSource`
+  + `IZoomSDKVirtualAudioMic` + FFmpeg media pipeline.
+- **Option B — Headless Chromium + Zoom Web SDK** + virtual webcam
+  (`v4l2loopback`) + virtual mic (PulseAudio null sink) + FFmpeg piping
+  raw frames into the kernel devices.
+
+For the requirement set (30 min+ playback, 5 s start latency, native
+control surface for pause/skip/seek, dev team owning both build
+pipelines, GitHub Actions C++ build acceptable), **Option A is the
+better long-term fit**:
+
+|                          | A (Native SDK) | B (Headless Chrome) |
+|--------------------------|----------------|---------------------|
+| Per-session memory       | ~150–200 MB    | ~400–500 MB         |
+| Per-session start time   | 2–3 s ✅       | 5–15 s ⚠️           |
+| Long-form stability      | High           | Browser lifecycle risk |
+| Image size               | ~600 MB        | ~1.2 GB             |
+| Single-host ceiling      | ~30–50 sessions| ~10–15 sessions     |
+| Time to PoC              | 2–4 weeks      | ~1 week             |
+| Build complexity         | High (SDK)     | Low (npm + chromium)|
+| Observability            | Lower (SDK black box) | Higher (DevTools) |
+
+### Spike before commitment
+
+Before fully committing to A, run a **2-day spike** against Zoom's
+official sample (`meetingsdk-headless-linux-sample`, Apache 2.0). Goals:
+
+1. Day 1: Build the sample in GitHub Actions, confirm Zoom SDK download
+   pipeline is workable inside CI.
+2. Day 2: Run the sample locally; join a test meeting as a bot; play an
+   MP4 from disk into the meeting; verify another client sees video +
+   hears audio.
+
+- If spike succeeds → **commit to A**; `zoom_mediabot` is built on the
+  sample as a starting point.
+- If spike fails (sample is broken/abandoned, or license blocks CI
+  build) → **fall back to B**.
+
+### Why not Erlang Port
+
+A Port would spawn the mediabot binary as a child of the BEAM, which
+forces co-location on a single host *and* drags all heavy media
+dependencies (Chromium or Zoom SDK shared libs) into the same OS image
+as the 10 MB control plane. This breaks the separation that justified
+the split in the first place. Sidecar-container + localhost HTTP keeps
+the same single-host deployment shape with proper isolation, and ports
+forward unchanged when we eventually scale out.
+
+### Why not `durable_server`
+
+`durable_server` provides automatic persistence and cluster-wide
+re-placement for *in-BEAM GenServer state*. It does not supervise OS
+processes. It may later be useful to harden the ZoomGate `Session`
+GenServer itself across BEAM node failures, but that is an unrelated
+concern.
+
+## Server platform
+
+- **CPU architecture**: x86_64 (Zoom Meeting SDK is first-class on
+  x86_64; arm64 support lags and is intermittent; hardware video
+  encoding offload — VA-API, NVENC — is mature on x86 servers).
+- **OS**: Ubuntu 22.04 LTS (Zoom Linux SDK supported).
+- **Initial sizing** (target 5 concurrent sessions): 16 vCPU, 32 GB
+  RAM, NVMe storage for media cache, 1 Gbps NIC. Optional NVIDIA T4/L4
+  for NVENC if CPU encoding becomes the bottleneck.
+
+## Consequences
+
+### Positive
+
+- The 10 MB pure-Elixir control plane stays unchanged. No regression
+  for users who only need waiting-room control.
+- Media plane can fail, restart, or be deployed independently of the
+  control plane.
+- HTTP interface lets the media bot be re-implemented later (A↔B↔C)
+  without touching ZoomGate code.
+- Single-host docker-compose for v1 keeps operational complexity low;
+  same interface scales to per-session K8s Jobs when needed.
+
+### Negative
+
+- Two Zoom participants per "playing meeting" — visible in the roster
+  to host. Naming convention (e.g., display_name = session title;
+  email = internal UUID) needed.
+- The control bot must admit the media bot from the waiting room. If
+  the control bot is unhealthy at the moment the media bot joins, the
+  media bot stalls in the waiting room.
+- Two SDK credential paths to manage (RWG via Web SDK signature + Raw
+  Data via Native SDK), though they can share the same Marketplace app.
+- A's path requires the team to own a C++ build pipeline.
+
+### Neutral / to revisit
+
+- Subtitle delivery: burn-in (FFmpeg `subtitles` filter) for PoC,
+  Zoom Closed Captioning API later for toggleable / multi-language
+  captions. The RWG protocol module does not yet have CC opcodes.
+- Whether `zoom_mediabot`'s internal HTTP orchestrator is Go or Elixir
+  is deferred. Worker is C++ regardless.
+
+## Open questions
+
+Tracked in `docs/plans/media-playback.md`.
+
+## References
+
+- Zoom Meeting SDK for Linux — Raw Data: `IZoomSDKVideoSource`,
+  `IZoomSDKVirtualAudioMic`.
+- Zoom official sample: `zoom/meetingsdk-headless-linux-sample`
+  (Apache 2.0). Validate URL during spike.
+- `lib/zoom_gate/meeting_bot.ex` — current pure-Elixir RWG client.
+- `lib/zoom_gate/session.ex` — pluggable bot module via
+  `:zoom_gate, :bot_module` config.

--- a/docs/plans/media-playback.md
+++ b/docs/plans/media-playback.md
@@ -1,0 +1,213 @@
+# Plan: Media Playback (Two-Bot Architecture)
+
+Implementation plan for the decision in
+[`docs/adr/0001-media-playback-architecture.md`](../adr/0001-media-playback-architecture.md).
+
+Branch: `claude/bot-video-playback-1ZjMY`.
+
+## Goal
+
+Enable ZoomGate consumers to play pre-recorded video + audio into an
+active Zoom meeting, with playback controls (pause / resume / skip /
+seek), eventually with playlist and subtitle support. Target 5 concurrent
+sessions on a single host.
+
+## Approach summary
+
+- Add a new sidecar service, `zoom_mediabot`, under `mediabot/` in this
+  monorepo.
+- `zoom_mediabot` exposes a small HTTP API.
+- Each playback session corresponds to one `zoom_mediabot` worker
+  subprocess that joins the meeting as an independent Zoom participant
+  (separate from the existing ZoomGate control bot).
+- ZoomGate pre-registers the media bot's identifier (an `email` field),
+  detects its arrival in the waiting room via existing RWG roster
+  events, and admits it automatically.
+- All coordination is via ZoomGate ↔ `zoom_mediabot` HTTP. The two bots
+  never talk to each other; they meet only in the Zoom meeting itself.
+
+## Phases
+
+### Phase 0 — Spike: validate Option A (2 days)
+
+Goal: De-risk Option A before committing.
+
+Tasks:
+
+- [ ] Confirm the Zoom official sample
+      `zoom/meetingsdk-headless-linux-sample` is current and
+      Apache-licensed.
+- [ ] Run the sample locally: build, link against the Linux Meeting SDK,
+      join a test meeting as a bot, play an MP4 from disk.
+- [ ] Verify a separate test client sees the bot's video and hears
+      audio.
+- [ ] Reproduce the build in a GitHub Actions runner (the SDK download
+      step must work in CI with a stored credential).
+- [ ] Decide: commit to A, or fall back to B.
+
+Acceptance:
+
+- A bot session plays a 30 s test MP4 end-to-end in a real meeting.
+- The same build runs green in CI.
+
+Exit:
+
+- If A passes → proceed to Phase 1 building on the sample.
+- If A fails → spike Option B for 1–2 days (`v4l2loopback` + headless
+  Chrome + Zoom Web SDK joining a meeting and consuming a virtual
+  device). On success, switch the rest of this plan to B.
+
+### Phase 1 — MVP: single-video playback (1 session, no controls)
+
+Goal: One mediabot can join a meeting and play one MP4 from a URL,
+end-to-end, with ZoomGate orchestrating.
+
+Tasks:
+
+- [ ] Create `mediabot/` subdirectory with `Dockerfile`,
+      `CMakeLists.txt`, `worker/`, `orchestrator/`.
+- [ ] Worker (C++): SDK init → auth (JWT) → meeting join → FFmpeg
+      decode loop → push YUV420 frames via `IZoomSDKVideoSource` and
+      PCM via `IZoomSDKVirtualAudioMic` → leave on EOF.
+- [ ] Orchestrator HTTP server (Go or Elixir — see open question OQ-1):
+      `POST /sessions` spawns a worker subprocess; `GET /sessions/:id`
+      returns state; `DELETE /sessions/:id` kills it.
+- [ ] Worker reports state to orchestrator via stdout JSON lines
+      (state, position, error).
+- [ ] ZoomGate side: `ZoomGate.MediaBot` GenServer (HTTP client to
+      mediabot), and `ZoomGate.play_media/3`, `ZoomGate.stop_media/1`
+      public API.
+- [ ] ZoomGate Session pre-registers a media-bot email in its state,
+      auto-admits when the matching identifier appears in roster /
+      `evt_hold_change`.
+- [ ] Verify the `Participant.merge_roster` pipeline actually surfaces
+      the `email` field. If not, choose an alternative identifier.
+- [ ] docker-compose with `zoom_gate` and `zoom_mediabot` services on
+      localhost.
+
+Acceptance:
+
+- From a test app, call `ZoomGate.play_media(meeting_id, video_url)`,
+  see the media bot enter the meeting and play the video to a separate
+  human participant.
+- Stop with `ZoomGate.stop_media(meeting_id)`; the bot leaves cleanly.
+
+Risks:
+
+- RWG roster may not expose `email` in the shape we expect. Mitigation:
+  capture full roster payload during Phase 1 testing; fall back to
+  another reliable pre-registerable field.
+- Bot's video/audio may be muted or video-off on join. Mitigation: in
+  the worker, explicitly request video-on and audio-on after join.
+
+### Phase 2 — Playback controls
+
+Goal: pause / resume / skip / seek work mid-playback.
+
+Tasks:
+
+- [ ] Worker: add internal state machine
+      `idle → ready → playing ⇄ paused`, with `seek(t)` and
+      `skip_to_next` transitions.
+- [ ] Orchestrator: add `POST /sessions/:id/pause`, `.../resume`,
+      `.../seek`, `.../skip` endpoints — forward as commands to worker
+      stdin.
+- [ ] ZoomGate: expose `ZoomGate.pause_media/1`, `.resume_media/1`,
+      `.seek_media/2`, `.skip_media/1` as the public API surface.
+- [ ] Webhook events back to ZoomGate: `playing`, `paused`,
+      `position`, `track_ended`, `error`.
+
+Acceptance:
+
+- Test app drives pause/resume/seek; participants see the change with
+  expected delay (< 1 s).
+
+### Phase 3 — Playlist
+
+Goal: a session plays a sequence of items; auto-advance on item end.
+
+Tasks:
+
+- [ ] Worker: maintain `playlist: [item]` and `current_index`; on EOF
+      of current item, decode next.
+- [ ] Orchestrator: `POST /sessions/:id/playlist` (replace),
+      `POST /sessions/:id/playlist/append`,
+      `POST /sessions/:id/skip` (already in Phase 2) advances index.
+- [ ] ZoomGate API: `ZoomGate.set_playlist/2`,
+      `ZoomGate.append_playlist/2`, `ZoomGate.skip_track/1`.
+- [ ] Webhook event `track_changed` carrying new index + item metadata.
+
+Acceptance:
+
+- A 3-item playlist plays back-to-back without re-creating the session
+  or rejoining the meeting.
+
+### Phase 4 — Subtitles
+
+Goal: subtitle support, starting with burn-in.
+
+Tasks:
+
+- [ ] Worker: accept `subtitle_url` per item; if present, configure
+      FFmpeg `subtitles` filter when decoding.
+- [ ] Optional later: Zoom Closed Captioning API path — worker emits
+      position events, ZoomGate sends CC text events via RWG. This
+      requires adding CC opcodes to
+      `lib/zoom_gate/meeting_bot/protocol.ex`.
+
+Acceptance:
+
+- A playlist item with an SRT renders captions in the video sent to the
+  meeting.
+
+### Phase 5 — Concurrency: 5 sessions on one host
+
+Goal: 5 simultaneous playback sessions on the target server.
+
+Tasks:
+
+- [ ] Stress test: 5 sessions, each playing a 30 min video, observe
+      CPU, RAM, network upload.
+- [ ] Tune: worker per-session resource budget; orchestrator concurrent
+      session cap; consider VA-API / NVENC if CPU-bound.
+- [ ] Define container sizing in Docker Compose limits.
+
+Acceptance:
+
+- 5 concurrent sessions stable for 30 min with < 80% CPU and no
+  failures.
+
+## Open questions
+
+| ID | Question | Resolution path |
+|----|----------|-----------------|
+| OQ-1 | Orchestrator language (Go vs Elixir)? | Decide during Phase 1 design; default Go. |
+| OQ-2 | Credential transport ZG → mediabot (env var, short-lived token, or per-request payload)? | Per-request payload for v1 (internal network). |
+| OQ-3 | Media file source (S3 presigned URL, local volume, plain HTTPS URL)? | HTTPS URL accepted by worker; consumer chooses. |
+| OQ-4 | Identifier field for auto-admit (`email` confirmed via roster, or another)? | Verify in Phase 1 implementation. |
+| OQ-5 | Subtitles mode for v1 (burn-in vs CC)? | Burn-in. CC deferred to later phase. |
+| OQ-6 | Concurrent ceiling beyond 5? Trigger for K8s migration? | Revisit after Phase 5 measurements. |
+| OQ-7 | Failure semantics: media bot crashes mid-playlist — restart? skip? notify only? | Decide during Phase 3. |
+| OQ-8 | Should the control bot's Session GenServer become `durable_server`-backed for HA later? | Out of scope of this plan; track separately. |
+
+## Out of scope
+
+- Receiving raw data from the meeting (recording participants). The
+  separate Raw Data **receive** capability requires Zoom approval and
+  is unrelated.
+- Multi-host deployment / Kubernetes Jobs. Triggered only if Phase 5
+  measurements exceed single-host capacity.
+- Marketplace publication. Internal-only use; no submission needed.
+
+## Housekeeping (separate from feature work)
+
+- [ ] Update `CLAUDE.md` — the current document still describes a
+      C++-SDK-over-Port architecture that no longer matches reality.
+      Reflect the pure-Elixir RWG client and the new two-bot media
+      split.
+- [ ] Decide fate of `native/zoom_worker.cpp` and the `worker_path`
+      config entry. If Phase 0 commits to Option A, evolve the file
+      into the new mediabot worker. Otherwise delete.
+- [ ] Verify `Participant.merge_roster` and `participant.ex` actually
+      expose `email`. If not, plumb it through (small, isolated
+      change).


### PR DESCRIPTION
## Summary

Add architectural decision record (ADR) and detailed implementation plan for media playback feature, establishing a two-bot split architecture where ZoomGate (control plane) orchestrates a separate `zoom_mediabot` service (media plane) for video/audio playback into Zoom meetings.

## Changes

- **`docs/adr/0001-media-playback-architecture.md`** — ADR documenting the decision to adopt a two-bot architecture:
  - Rationale: RWG WebSocket is signalling-only; media requires SDK integration
  - Design: independent Zoom participants (control bot + media bot) coordinated via HTTP
  - Comparison of Option A (Native C++ SDK) vs Option B (Headless Chrome + v4l2loopback)
  - Recommendation: Option A with 2-day spike to validate against Zoom's official sample
  - Platform requirements: x86_64 Ubuntu 22.04 LTS, target 5 concurrent sessions

- **`docs/plans/media-playback.md`** — Phased implementation plan with 5 phases + spike:
  - **Phase 0 (Spike)**: Validate Option A using Zoom's `meetingsdk-headless-linux-sample`
  - **Phase 1 (MVP)**: Single-video playback with ZoomGate orchestration and auto-admit
  - **Phase 2**: Playback controls (pause/resume/seek/skip)
  - **Phase 3**: Playlist support with auto-advance
  - **Phase 4**: Subtitle support (burn-in initially)
  - **Phase 5**: Concurrency testing and tuning for 5 sessions
  - Open questions (8 items) and out-of-scope items documented
  - Housekeeping tasks for existing codebase alignment

## Implementation Details

- **Architecture**: ZoomGate remains a pure control-plane proxy (~10 MB); `zoom_mediabot` is a separate sidecar service handling media via Native SDK + FFmpeg
- **Coordination**: HTTP API between ZoomGate and mediabot; bots meet only in the Zoom meeting itself
- **Identifier strategy**: Pre-register media bot by email; ZoomGate auto-admits from waiting room when roster event arrives
- **Deployment**: Docker Compose for v1 (single host); HTTP interface scales unchanged to K8s later
- **Risk mitigation**: 2-day spike before full commitment; fallback to Option B if Option A fails

## Related Issues

Implements decision from branch `claude/bot-video-playback-1ZjMY`.

https://claude.ai/code/session_016mx1P5nDKpXkTFZY69DAMB